### PR TITLE
Add conditional Gradle `detect` steps for app and humanoperator in manual CI

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -104,6 +104,14 @@ jobs:
       if: needs.detect-changes.outputs.humanoperator_changed == 'true' || needs.detect-changes.outputs.shared_changed == 'true'
       run: ./gradlew :humanoperator:compileDebugKotlin
 
+    - name: Detect (app)
+      if: needs.detect-changes.outputs.app_changed == 'true' || needs.detect-changes.outputs.shared_changed == 'true'
+      run: ./gradlew :app:detect
+
+    - name: Detect (humanoperator)
+      if: needs.detect-changes.outputs.humanoperator_changed == 'true' || needs.detect-changes.outputs.shared_changed == 'true'
+      run: ./gradlew :humanoperator:detect
+
   build:
     needs: [detect-changes, compile-check]
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- Ensure module-specific `detect` Gradle tasks run early in the manual CI workflow for the `app` and `humanoperator` modules when those modules (or shared code) change.

### Description
- Added two conditional steps to `.github/workflows/manual.yml` named `Detect (app)` and `Detect (humanoperator)` that run `./gradlew :app:detect` and `./gradlew :humanoperator:detect` respectively, gated by the same `if` conditions used for Kotlin compilation.

### Testing
- No automated unit or integration tests were modified or run as part of this change; this PR only updates the CI workflow file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c30ea525cc83219890cad4a4e1b85a)