### PR TITLE
Fix beschädigten Mistral-Retry-Block in PhotoReasoningViewModel

### DIFF
--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -1203,28 +1203,28 @@ private fun reasonWithMistral(
                     markKeyCooldown(selectedKey, requestEndMs)
                     blockedKeysThisRound.add(selectedKey)
                     consecutiveFailures++
-                    if (consecutiveFailures >= 5) {
-                        throw IOException("Mistral request failed after 5 attempts: ${e.message}", e)
+                    if (consecutiveFailures >= maxAttempts) {
+                        throw IOException("Mistral request failed after $maxAttempts attempts: ${e.message}", e)
                     }
                     withContext(Dispatchers.Main) {
                         replaceAiMessageText(
-                        if (consecutiveFailures >= maxAttempts) {
-                            throw IOException("Mistral request failed after $maxAttempts attempts: ${e.message}", e)
+                            "Mistral Netzwerkfehler (Versuch $consecutiveFailures/$maxAttempts). Wiederhole...",
+                            isPending = true
                         )
                     }
                 }
-                                "Mistral Netzwerkfehler (Versuch $consecutiveFailures/$maxAttempts). Wiederhole...",
+            }
 
             if (stopExecutionFlag.get()) {
                 throw IOException("Mistral request aborted.")
             }
 
-            val finalResponse = response ?: throw IOException("Mistral request failed after 5 attempts.")
+            val finalResponse = response ?: throw IOException("Mistral request failed after $maxAttempts attempts.")
 
             if (!finalResponse.isSuccessful) {
                 val errBody = finalResponse.body?.string()
                 finalResponse.close()
-            val finalResponse = response ?: throw IOException("Mistral request failed after $maxAttempts attempts.")
+                throw IOException("Mistral Error ${finalResponse.code}: $errBody")
             }
 
             val body = finalResponse.body ?: throw IOException("Empty response body from Mistral")


### PR DESCRIPTION
### Motivation
- Behebt einen Syntax-/Parserbruch in `reasonWithMistral(...)`, der dazu führte, dass nachfolgende Methoden als lokale Funktionen fehlinterpretiert wurden und viele `Unresolved reference`-Fehler erzeugt wurden.

### Description
- Repariert den defekten `catch (IOException)`-Block im Mistral-Request-Loop und stellt die korrekte Klammerstruktur wieder her in `app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt`.
- Ersetzt die fehlerhafte Retry-Logik durch eine konsistente Prüfung gegen `maxAttempts` und wirft bei Überschreiten eine aussagekräftige `IOException`.
- Stellt `replaceAiMessageText(...)` mit dem richtigen Text-Argument und `isPending = true` wieder her, sodass Streaming-/Fehlermeldungen korrekt angezeigt werden.
- Entfernt die doppelte/korrupt eingefügte `finalResponse`-Zuweisung und wirft bei nicht-erfolgreichen Antworten korrekt `IOException` mit Fehlerkörper.

### Testing
- Versucht: `./gradlew :app:compileDebugKotlin` — vor der Änderung traten Parser-/Kompilierfehler auf (mehrere `Unresolved reference`) aufgrund des beschädigten Blocks, die durch die Änderungen adressiert wurden.
- Erneut ausgeführt: `./gradlew :app:compileDebugKotlin` — die Kompilierung konnte in dieser Umgebung nicht abgeschlossen werden, weil die Android SDK-Location nicht konfiguriert war (`SDK location not found`), daher konnte ein vollständiger Gradle-Kompilierschritt hier nicht final bestätigt werden.
- Hinweis: Die korrigierten Codeblöcke sind syntaktisch wiederhergestellt und sollten die zuvor berichteten Kotlin-Parserfehler beseitigen; ein vollständiger Build sollte in einer Umgebung mit korrekt konfiguriertem Android SDK erfolgreich ausführbar sein.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caf009e2408331a990b44063c66678)