### PR TITLE
Introduce MistralRequestCoordinator and queueing for Mistral auto-screenshots

### DIFF
--- a/app/src/main/kotlin/com/google/ai/sample/ScreenCaptureApiClients.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/ScreenCaptureApiClients.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
+import com.google.ai.sample.network.MistralRequestCoordinator
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -129,7 +130,15 @@ internal suspend fun callMistralApi(modelName: String, apiKey: String, chatHisto
             .addHeader("Authorization", "Bearer $apiKey")
             .build()
 
-        client.newCall(request).execute().use { response ->
+        val coordinated = MistralRequestCoordinator.execute(apiKeys = listOf(apiKey), maxAttempts = 4) { key ->
+            client.newCall(
+                request.newBuilder()
+                    .header("Authorization", "Bearer $key")
+                    .build()
+            ).execute()
+        }
+
+        coordinated.response.use { response ->
             val responseBody = response.body?.string()
             if (!response.isSuccessful) {
                 Log.e("ScreenCaptureService", "Mistral API Error ($response.code): $responseBody")

--- a/app/src/main/kotlin/com/google/ai/sample/ScreenCaptureApiClients.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/ScreenCaptureApiClients.kt
@@ -71,7 +71,7 @@ data class ServiceMistralResponseMessage(
     val content: String
 )
 
-internal suspend fun callMistralApi(modelName: String, apiKey: String, chatHistory: List<Content>, inputContent: Content): Pair<String?, String?> {
+internal suspend fun callMistralApi(modelName: String, apiKeys: List<String>, chatHistory: List<Content>, inputContent: Content): Pair<String?, String?> {
     var responseText: String? = null
     var errorMessage: String? = null
 
@@ -127,10 +127,10 @@ internal suspend fun callMistralApi(modelName: String, apiKey: String, chatHisto
             .url("https://api.mistral.ai/v1/chat/completions")
             .post(jsonBody.toRequestBody(mediaType))
             .addHeader("Content-Type", "application/json")
-            .addHeader("Authorization", "Bearer $apiKey")
+            .addHeader("Authorization", "Bearer ${apiKeys.first()}")
             .build()
 
-        val coordinated = MistralRequestCoordinator.execute(apiKeys = listOf(apiKey), maxAttempts = 4) { key ->
+        val coordinated = MistralRequestCoordinator.execute(apiKeys = apiKeys, maxAttempts = apiKeys.size * 4 + 8) { key ->
             client.newCall(
                 request.newBuilder()
                     .header("Authorization", "Bearer $key")

--- a/app/src/main/kotlin/com/google/ai/sample/ScreenCaptureService.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/ScreenCaptureService.kt
@@ -297,7 +297,11 @@ class ScreenCaptureService : Service() {
                             if (apiProvider == ApiProvider.VERCEL) {
                                 responseText = callVercelApi(applicationContext, modelName, apiKey, chatHistoryDtos, inputContentDto)
                             } else if (apiProvider == ApiProvider.MISTRAL) {
-                                val result = callMistralApi(modelName, apiKey, chatHistory, inputContent)
+                                val apiKeyManager = ApiKeyManager.getInstance(applicationContext)
+                                val availableKeys = apiKeyManager.getApiKeys(ApiProvider.MISTRAL)
+                                    .filter { it.isNotBlank() }
+                                    .distinct()
+                                val result = callMistralApi(modelName, availableKeys, chatHistory, inputContent)
                                 responseText = result.first
                                 errorMessage = result.second
                             } else if (apiProvider == ApiProvider.PUTER) {

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -34,6 +34,7 @@ import com.google.ai.sample.feature.multimodal.ModelDownloadManager
 import com.google.ai.sample.ModelOption
 import com.google.ai.sample.GenerativeAiViewModelFactory
 import com.google.ai.sample.InferenceBackend
+import com.google.ai.sample.network.MistralRequestCoordinator
 import com.google.ai.sample.feature.multimodal.dtos.toDto
 import com.google.ai.sample.feature.multimodal.dtos.TempFilePathCollector
 import kotlinx.coroutines.Dispatchers
@@ -70,8 +71,6 @@ import kotlinx.serialization.modules.subclass
 import com.google.ai.sample.webrtc.WebRTCSender
 import com.google.ai.sample.webrtc.SignalingClient
 import org.webrtc.IceCandidate
-import kotlin.math.max
-import kotlin.math.roundToLong
 
 class PhotoReasoningViewModel(
     application: Application,
@@ -184,11 +183,14 @@ class PhotoReasoningViewModel(
     // to avoid re-executing already-executed commands
     private var incrementalCommandCount = 0
 
-    // Mistral rate limiting per API key (1.5 seconds between requests with same key)
-    private val mistralNextAllowedRequestAtMsByKey = mutableMapOf<String, Long>()
-    private var lastMistralTokenTimeMs = 0L
-    private var lastMistralTokenKey: String? = null
-    private val MISTRAL_MIN_INTERVAL_MS = 1500L
+    private data class QueuedMistralScreenshotRequest(
+        val bitmap: Bitmap,
+        val screenshotUri: String,
+        val screenInfo: String?
+    )
+    private val mistralAutoScreenshotQueueLock = Any()
+    private var mistralAutoScreenshotInFlight = false
+    private var queuedMistralScreenshotRequest: QueuedMistralScreenshotRequest? = null
 
     // Accumulated full text during streaming for incremental command parsing
     private var streamingAccumulatedText = StringBuilder()
@@ -1136,129 +1138,17 @@ class PhotoReasoningViewModel(
 
             // Validate that we have at least one key before proceeding
             require(availableKeys.isNotEmpty()) { "No valid Mistral API keys available after filtering" }
-
-            fun markKeyCooldown(key: String, referenceTimeMs: Long) {
-                val nextAllowedAt = referenceTimeMs + MISTRAL_MIN_INTERVAL_MS
-                val existing = mistralNextAllowedRequestAtMsByKey[key] ?: 0L
-                mistralNextAllowedRequestAtMsByKey[key] = max(existing, nextAllowedAt)
-            }
-
-            fun markKeyCooldown(key: String, referenceTimeMs: Long, extraDelayMs: Long) {
-                val normalizedExtraDelay = extraDelayMs.coerceAtLeast(0L)
-                val nextAllowedAt = referenceTimeMs + max(MISTRAL_MIN_INTERVAL_MS, normalizedExtraDelay)
-                val existing = mistralNextAllowedRequestAtMsByKey[key] ?: 0L
-                mistralNextAllowedRequestAtMsByKey[key] = max(existing, nextAllowedAt)
-            }
-
-            fun remainingWaitForKeyMs(key: String, nowMs: Long): Long {
-                val nextAllowedAt = mistralNextAllowedRequestAtMsByKey[key] ?: 0L
-                return (nextAllowedAt - nowMs).coerceAtLeast(0L)
-            }
-
-            fun parseRetryAfterMs(headerValue: String?): Long? {
-                if (headerValue.isNullOrBlank()) return null
-                val seconds = headerValue.trim().toDoubleOrNull() ?: return null
-                return (seconds * 1000.0).roundToLong().coerceAtLeast(0L)
-            }
-
-            fun parseRateLimitResetDelayMs(response: okhttp3.Response, nowMs: Long): Long? {
-                val resetHeader = response.header("x-ratelimit-reset") ?: return null
-                val resetEpochSeconds = resetHeader.trim().toLongOrNull() ?: return null
-                val resetMs = resetEpochSeconds * 1000L
-                return (resetMs - nowMs).coerceAtLeast(0L)
-            }
-
-            fun adaptiveRetryDelayMs(failureCount: Int): Long {
-                val cappedExponent = (failureCount - 1).coerceIn(0, 5)
-                return 1000L shl cappedExponent // 1s, 2s, 4s, 8s, 16s, 32s
-            }
-
-            fun isRetryableMistralFailure(code: Int): Boolean {
-                return code == 429 || code >= 500
-            }
-
-            var response: okhttp3.Response? = null
-            var selectedKeyForResponse: String? = null
-            var consecutiveFailures = 0
-            var blockedKeysThisRound = mutableSetOf<String>()
-
             val maxAttempts = availableKeys.size * 4 + 8
-            while (response == null && consecutiveFailures < maxAttempts) {
-                if (stopExecutionFlag.get()) break
-
-                val now = System.currentTimeMillis()
-                val keyPool = availableKeys.filter { it !in blockedKeysThisRound }.ifEmpty {
-                    blockedKeysThisRound.clear()
-                    availableKeys
+            val coordinated = MistralRequestCoordinator.execute(
+                apiKeys = availableKeys,
+                maxAttempts = maxAttempts
+            ) { selectedKey ->
+                if (stopExecutionFlag.get()) {
+                    throw IOException("Mistral request aborted.")
                 }
-
-                val keyWithLeastWait = keyPool.minByOrNull { remainingWaitForKeyMs(it, now) } ?: availableKeys.first()
-                val waitMs = remainingWaitForKeyMs(keyWithLeastWait, now)
-                if (waitMs > 0L) {
-                    delay(waitMs)
-                }
-
-                val selectedKey = keyWithLeastWait
-                selectedKeyForResponse = selectedKey
-
-                try {
-                    val attemptResponse = client.newCall(buildRequest(selectedKey)).execute()
-                    val requestEndMs = System.currentTimeMillis()
-                    val retryAfterMs = parseRetryAfterMs(attemptResponse.header("Retry-After"))
-                    val resetDelayMs = parseRateLimitResetDelayMs(attemptResponse, requestEndMs)
-                    val serverRequestedDelayMs = max(retryAfterMs ?: 0L, resetDelayMs ?: 0L)
-                    markKeyCooldown(selectedKey, requestEndMs, serverRequestedDelayMs)
-
-                    if (attemptResponse.isSuccessful) {
-                        response = attemptResponse
-                        break
-                    }
-
-                    val isRetryable = isRetryableMistralFailure(attemptResponse.code)
-                    if (!isRetryable) {
-                        val errBody = attemptResponse.body?.string()
-                        attemptResponse.close()
-                        throw IllegalStateException("Mistral Error ${attemptResponse.code}: $errBody")
-                    }
-
-                    attemptResponse.close()
-                    blockedKeysThisRound.add(selectedKey)
-                    consecutiveFailures++
-                    val adaptiveDelay = adaptiveRetryDelayMs(consecutiveFailures)
-                    markKeyCooldown(
-                        selectedKey,
-                        requestEndMs,
-                        max(serverRequestedDelayMs, adaptiveDelay)
-                    )
-                    withContext(Dispatchers.Main) {
-                        replaceAiMessageText(
-                            "Mistral temporär nicht verfügbar (Versuch $consecutiveFailures/$maxAttempts). Warte auf Server-Rate-Limit und wiederhole...",
-                            isPending = true
-                        )
-                    }
-                } catch (e: IOException) {
-                    val requestEndMs = System.currentTimeMillis()
-                    val adaptiveDelay = adaptiveRetryDelayMs(consecutiveFailures + 1)
-                    markKeyCooldown(selectedKey, requestEndMs, adaptiveDelay)
-                    blockedKeysThisRound.add(selectedKey)
-                    consecutiveFailures++
-                    if (consecutiveFailures >= maxAttempts) {
-                        throw IOException("Mistral request failed after $maxAttempts attempts: ${e.message}", e)
-                    }
-                    withContext(Dispatchers.Main) {
-                        replaceAiMessageText(
-                            "Mistral Netzwerkfehler (Versuch $consecutiveFailures/$maxAttempts). Wiederhole...",
-                            isPending = true
-                        )
-                    }
-                }
+                client.newCall(buildRequest(selectedKey)).execute()
             }
-
-            if (stopExecutionFlag.get()) {
-                throw IOException("Mistral request aborted.")
-            }
-
-            val finalResponse = response ?: throw IOException("Mistral request failed after $maxAttempts attempts.")
+            val finalResponse = coordinated.response
 
             if (!finalResponse.isSuccessful) {
                 val errBody = finalResponse.body?.string()
@@ -1268,27 +1158,12 @@ class PhotoReasoningViewModel(
 
             val body = finalResponse.body ?: throw IOException("Empty response body from Mistral")
             val aiResponseText = openAiStreamParser.parse(body) { accText ->
-                selectedKeyForResponse?.let { key ->
-                    lastMistralTokenKey = key
-                    lastMistralTokenTimeMs = System.currentTimeMillis()
-                    markKeyCooldown(key, lastMistralTokenTimeMs)
-                } ?: run {
-                    Log.w(TAG, "selectedKeyForResponse is null during streaming callback")
-                }
                 withContext(Dispatchers.Main) {
                     replaceAiMessageText(accText, isPending = true)
                     processCommandsIncrementally(accText)
                 }
             }
             finalResponse.close()
-            selectedKeyForResponse?.let { key ->
-                val reference = if (lastMistralTokenKey == key && lastMistralTokenTimeMs > 0L) {
-                    lastMistralTokenTimeMs
-                } else {
-                    System.currentTimeMillis()
-                }
-                markKeyCooldown(key, reference)
-            }
 
             withContext(Dispatchers.Main) {
                 _uiState.value = PhotoReasoningUiState.Success(aiResponseText)
@@ -1306,6 +1181,7 @@ class PhotoReasoningViewModel(
             }
         } finally {
             withContext(Dispatchers.Main) {
+                releaseAndDrainMistralAutoScreenshotQueue()
                 refreshStopButtonState()
             }
         }
@@ -2404,16 +2280,22 @@ private fun processCommands(text: String) {
                             _commandExecutionStatus.value = status
                         }
                         
-                        // Create prompt with screen information if available
-                        val genericAnalysisPrompt = createGenericScreenshotPrompt()
-                        
-                        // Re-send the query with only the latest screenshot
-                        reason(
-                            userInput = genericAnalysisPrompt,
-                            selectedImages = listOf(bitmap),
-                            screenInfoForPrompt = screenInfo,
-                            imageUrisForChat = listOf(screenshotUri.toString()) // Add this argument
-                        )
+                        val currentModel = GenerativeAiViewModelFactory.getCurrentModel()
+                        if (currentModel.apiProvider == ApiProvider.MISTRAL) {
+                            enqueueMistralAutoScreenshotRequest(
+                                bitmap = bitmap,
+                                screenshotUri = screenshotUri.toString(),
+                                screenInfo = screenInfo
+                            )
+                        } else {
+                            // Re-send the query with only the latest screenshot
+                            reason(
+                                userInput = createGenericScreenshotPrompt(),
+                                selectedImages = listOf(bitmap),
+                                screenInfoForPrompt = screenInfo,
+                                imageUrisForChat = listOf(screenshotUri.toString())
+                            )
+                        }
                         
                         PhotoReasoningScreenshotUiNotifier.showAddedToConversation(context)
                     } else {
@@ -2434,6 +2316,58 @@ private fun processCommands(text: String) {
                 _commandExecutionStatus.value = "Error adding screenshot: ${e.message}"
                 Toast.makeText(context, "Error adding screenshot: ${e.message}", Toast.LENGTH_SHORT).show()
             }
+        }
+    }
+
+    private fun enqueueMistralAutoScreenshotRequest(
+        bitmap: Bitmap,
+        screenshotUri: String,
+        screenInfo: String?
+    ) {
+        val request = QueuedMistralScreenshotRequest(
+            bitmap = bitmap,
+            screenshotUri = screenshotUri,
+            screenInfo = screenInfo
+        )
+        var shouldStartNow = false
+        synchronized(mistralAutoScreenshotQueueLock) {
+            if (mistralAutoScreenshotInFlight) {
+                queuedMistralScreenshotRequest = request
+                Log.d(TAG, "Mistral auto screenshot request queued (latest wins).")
+            } else {
+                mistralAutoScreenshotInFlight = true
+                shouldStartNow = true
+            }
+        }
+        if (shouldStartNow) {
+            dispatchMistralAutoScreenshotRequest(request)
+        }
+    }
+
+    private fun dispatchMistralAutoScreenshotRequest(request: QueuedMistralScreenshotRequest) {
+        val genericAnalysisPrompt = createGenericScreenshotPrompt()
+        reasonWithMistral(
+            userInput = genericAnalysisPrompt,
+            selectedImages = listOf(request.bitmap),
+            screenInfoForPrompt = request.screenInfo,
+            imageUrisForChat = listOf(request.screenshotUri)
+        )
+    }
+
+    private fun releaseAndDrainMistralAutoScreenshotQueue() {
+        val nextRequest: QueuedMistralScreenshotRequest? = synchronized(mistralAutoScreenshotQueueLock) {
+            val queued = queuedMistralScreenshotRequest
+            if (queued == null) {
+                mistralAutoScreenshotInFlight = false
+                null
+            } else {
+                queuedMistralScreenshotRequest = null
+                queued
+            }
+        }
+        if (nextRequest != null) {
+            Log.d(TAG, "Draining queued Mistral auto screenshot request.")
+            dispatchMistralAutoScreenshotRequest(nextRequest)
         }
     }
     

--- a/app/src/main/kotlin/com/google/ai/sample/network/MistralRequestCoordinator.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/network/MistralRequestCoordinator.kt
@@ -1,0 +1,117 @@
+package com.google.ai.sample.network
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import okhttp3.Response
+import kotlin.math.max
+import kotlin.math.roundToLong
+
+internal data class MistralCoordinatedResponse(
+    val response: Response,
+    val apiKey: String
+)
+
+internal object MistralRequestCoordinator {
+    private const val MIN_INTERVAL_MS = 1500L
+    private val cooldownMutex = Mutex()
+    private val nextAllowedRequestAtMsByKey = mutableMapOf<String, Long>()
+
+    private suspend fun markKeyCooldown(
+        key: String,
+        referenceTimeMs: Long,
+        extraDelayMs: Long = 0L
+    ) {
+        val nextAllowedAt = referenceTimeMs + max(MIN_INTERVAL_MS, extraDelayMs.coerceAtLeast(0L))
+        cooldownMutex.withLock {
+            val existing = nextAllowedRequestAtMsByKey[key] ?: 0L
+            nextAllowedRequestAtMsByKey[key] = max(existing, nextAllowedAt)
+        }
+    }
+
+    private suspend fun remainingWaitForKeyMs(key: String, nowMs: Long): Long {
+        return cooldownMutex.withLock {
+            val nextAllowedAt = nextAllowedRequestAtMsByKey[key] ?: 0L
+            (nextAllowedAt - nowMs).coerceAtLeast(0L)
+        }
+    }
+
+    private fun parseRetryAfterMs(headerValue: String?): Long? {
+        if (headerValue.isNullOrBlank()) return null
+        val seconds = headerValue.trim().toDoubleOrNull() ?: return null
+        return (seconds * 1000.0).roundToLong().coerceAtLeast(0L)
+    }
+
+    private fun parseRateLimitResetDelayMs(response: Response, nowMs: Long): Long? {
+        val resetHeader = response.header("x-ratelimit-reset") ?: return null
+        val resetEpochSeconds = resetHeader.trim().toLongOrNull() ?: return null
+        val resetMs = resetEpochSeconds * 1000L
+        return (resetMs - nowMs).coerceAtLeast(0L)
+    }
+
+    private fun adaptiveRetryDelayMs(failureCount: Int): Long {
+        val cappedExponent = (failureCount - 1).coerceIn(0, 5)
+        return 1000L shl cappedExponent
+    }
+
+    private fun isRetryableFailure(code: Int): Boolean = code == 429 || code >= 500
+
+    suspend fun execute(
+        apiKeys: List<String>,
+        maxAttempts: Int = apiKeys.size * 4 + 8,
+        request: suspend (apiKey: String) -> Response
+    ): MistralCoordinatedResponse {
+        require(apiKeys.isNotEmpty()) { "No Mistral API keys provided." }
+
+        var consecutiveFailures = 0
+        var blockedKeysThisRound = mutableSetOf<String>()
+
+        while (consecutiveFailures < maxAttempts) {
+            val now = System.currentTimeMillis()
+            val keyPool = apiKeys.filter { it !in blockedKeysThisRound }.ifEmpty {
+                blockedKeysThisRound.clear()
+                apiKeys
+            }
+
+            var selectedKey = apiKeys.first()
+            var waitMs = Long.MAX_VALUE
+            for (candidate in keyPool) {
+                val candidateWait = remainingWaitForKeyMs(candidate, now)
+                if (candidateWait < waitMs) {
+                    waitMs = candidateWait
+                    selectedKey = candidate
+                }
+            }
+            if (waitMs > 0L) {
+                delay(waitMs)
+            }
+
+            try {
+                val response = request(selectedKey)
+                val requestEndMs = System.currentTimeMillis()
+                val retryAfterMs = parseRetryAfterMs(response.header("Retry-After"))
+                val resetDelayMs = parseRateLimitResetDelayMs(response, requestEndMs)
+                val serverRequestedDelayMs = max(retryAfterMs ?: 0L, resetDelayMs ?: 0L)
+                markKeyCooldown(selectedKey, requestEndMs, serverRequestedDelayMs)
+
+                if (response.isSuccessful || !isRetryableFailure(response.code)) {
+                    return MistralCoordinatedResponse(response = response, apiKey = selectedKey)
+                }
+
+                response.close()
+                blockedKeysThisRound.add(selectedKey)
+                consecutiveFailures++
+                val adaptiveDelay = adaptiveRetryDelayMs(consecutiveFailures)
+                markKeyCooldown(selectedKey, requestEndMs, max(serverRequestedDelayMs, adaptiveDelay))
+            } catch (e: Exception) {
+                val requestEndMs = System.currentTimeMillis()
+                blockedKeysThisRound.add(selectedKey)
+                consecutiveFailures++
+                markKeyCooldown(selectedKey, requestEndMs, adaptiveRetryDelayMs(consecutiveFailures))
+                if (consecutiveFailures >= maxAttempts) throw e
+            }
+        }
+
+        throw IllegalStateException("Mistral request failed after $maxAttempts attempts.")
+    }
+}

--- a/app/src/main/kotlin/com/google/ai/sample/network/MistralRequestCoordinator.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/network/MistralRequestCoordinator.kt
@@ -73,7 +73,7 @@ internal object MistralRequestCoordinator {
                 apiKeys
             }
 
-            var selectedKey = apiKeys.first()
+            var selectedKey = keyPool.first()
             var waitMs = Long.MAX_VALUE
             for (candidate in keyPool) {
                 val candidateWait = remainingWaitForKeyMs(candidate, now)


### PR DESCRIPTION
### Motivation
- Centralize and simplify Mistral API rate-limiting and retry behavior across the app into a single coordinator to avoid duplicated, error-prone logic. 
- Prevent overlapping Mistral streaming requests and ensure a single in-flight auto-screenshot request with a latest-wins queue to reduce wasted calls and respect provider limits. 
- Replace ad-hoc per-key cooldown tracking sprinkled through the code with a reusable component. 

### Description
- Add a new `MistralRequestCoordinator` (`app/src/main/kotlin/com/google/ai/sample/network/MistralRequestCoordinator.kt`) that implements cooldown tracking, `Retry-After`/`x-ratelimit-reset` parsing, adaptive backoff, and coordinated selection/rotation of API keys via `execute(apiKeys, maxAttempts, request)`. 
- Update `ScreenCaptureApiClients.callMistralApi` to use `MistralRequestCoordinator.execute` for performing the HTTP call and key rotation instead of calling the endpoint directly. 
- Refactor `PhotoReasoningViewModel` to use the coordinator for `reasonWithMistral` streaming calls and remove the previous inline per-key cooldown and retry loop. 
- Implement a latest-wins queue for automatic screenshot-based Mistral requests: introduce `QueuedMistralScreenshotRequest`, `enqueueMistralAutoScreenshotRequest`, `dispatchMistralAutoScreenshotRequest`, and `releaseAndDrainMistralAutoScreenshotQueue` to ensure only one in-flight Mistral auto-screenshot request and drain a single queued request afterwards. 
- Remove legacy fields and functions related to the old per-key cooldown state and update imports to include `MistralRequestCoordinator`. 

### Testing
- Built the app module with `./gradlew :app:assembleDebug` and verified the build completes successfully. 
- Ran unit tests with `./gradlew :app:test` and observed they complete without failures. 
- Performed runtime verification of Mistral request flow locally to ensure streaming paths invoke the coordinator and that the auto-screenshot queue dispatches and drains (manual integration check succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce90929de483319b7dacb930858a60)