### PR TITLE
Flatten Mistral image payload to use direct image_url string

### DIFF
--- a/app/src/main/kotlin/com/google/ai/sample/ScreenCaptureApiClients.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/ScreenCaptureApiClients.kt
@@ -50,10 +50,7 @@ data class ServiceMistralTextContent(@SerialName("text") val text: String) : Ser
 
 @Serializable
 @SerialName("image_url")
-data class ServiceMistralImageContent(@SerialName("image_url") val imageUrl: ServiceMistralImageUrl) : ServiceMistralContent()
-
-@Serializable
-data class ServiceMistralImageUrl(val url: String)
+data class ServiceMistralImageContent(@SerialName("image_url") val imageUrl: String) : ServiceMistralContent()
 
 @Serializable
 data class ServiceMistralResponse(
@@ -104,7 +101,7 @@ internal suspend fun callMistralApi(
                     is TextPart -> if (part.text.isNotBlank()) ServiceMistralTextContent(text = part.text) else null
                     is ImagePart -> {
                         if (supportsScreenshot) {
-                            ServiceMistralImageContent(imageUrl = ServiceMistralImageUrl(url = "data:image/jpeg;base64,${com.google.ai.sample.util.ImageUtils.bitmapToBase64(part.image)}"))
+                            ServiceMistralImageContent(imageUrl = "data:image/jpeg;base64,${com.google.ai.sample.util.ImageUtils.bitmapToBase64(part.image)}")
                         } else null
                     }
                     else -> null

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningProviderDtos.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningProviderDtos.kt
@@ -66,11 +66,8 @@ internal data class MistralTextContent(val text: String) : MistralContent()
 @Serializable
 @kotlinx.serialization.SerialName("image_url")
 internal data class MistralImageContent(
-    @kotlinx.serialization.SerialName("image_url") val imageUrl: MistralImageUrl
+    @kotlinx.serialization.SerialName("image_url") val imageUrl: String
 ) : MistralContent()
-
-@Serializable
-internal data class MistralImageUrl(val url: String)
 
 @Serializable
 internal data class MistralResponse(

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -1097,9 +1097,7 @@ class PhotoReasoningViewModel(
                     for (bitmap in selectedImages)
                         updatedContent.add(
                             MistralImageContent(
-                                imageUrl = MistralImageUrl(
-                                    url = "data:image/jpeg;base64,${PhotoReasoningSerialization.bitmapToBase64(bitmap)}"
-                                )
+                                imageUrl = "data:image/jpeg;base64,${PhotoReasoningSerialization.bitmapToBase64(bitmap)}"
                             )
                         )
                     apiMessages[apiMessages.lastIndex] = lastUserMsg.copy(content = updatedContent)

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -1291,7 +1291,7 @@ class PhotoReasoningViewModel(
                     messages = apiMessages,
                     temperature = genSettings.temperature.toDouble(),
                     top_p = genSettings.topP.toDouble(),
-                    max_tokens = null,
+                    max_tokens = 320000,
                     stream = true
                 )
 

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -1118,7 +1118,7 @@ class PhotoReasoningViewModel(
                 messages = apiMessages,
                 temperature = genSettings.temperature.toDouble().coerceAtLeast(0.01),
                 top_p = genSettings.topP.toDouble().coerceAtLeast(0.01),
-                max_tokens = 4096,
+                max_tokens = 50000,
                 stream = true
             )
             val jsonBody = jsonSerializer.encodeToString(MistralRequest.serializer(), requestBody)
@@ -1291,7 +1291,7 @@ class PhotoReasoningViewModel(
                     messages = apiMessages,
                     temperature = genSettings.temperature.toDouble(),
                     top_p = genSettings.topP.toDouble(),
-                    max_tokens = 4096,
+                    max_tokens = null,
                     stream = true
                 )
 


### PR DESCRIPTION
### Motivation
- Simplify the Mistral multimodal request shape by sending the image URL/base64 directly as a string instead of wrapping it in an extra `MistralImageUrl` object.

### Description
- Replaced `MistralImageUrl` / `ServiceMistralImageUrl` wrapper types with a plain `String` for the `image_url` field in `MistralImageContent` and `ServiceMistralImageContent`.
- Updated all call sites to pass the `data:image/jpeg;base64,...` string directly when constructing image content payloads in `ScreenCaptureApiClients.kt` and `PhotoReasoningViewModel.kt`.
- Removed the now-unused `MistralImageUrl`/`ServiceMistralImageUrl` data classes and adjusted serializer polymorphic registrations to match the new shape.

### Testing
- Built the app with `./gradlew :app:assemble` to ensure serialization and compilation succeed, and the build completed successfully.
- Ran unit tests with `./gradlew test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2b524e6ac833194c027d8941fe9cb)