### PR TITLE
LiteRT: Native-Bibliothek vor Gemma‑4-Engine laden

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,7 +111,7 @@ dependencies {
     // MediaPipe GenAI for offline inference (LLM)
     implementation("com.google.mediapipe:tasks-genai:0.10.32")
     // LiteRT-LM for newer offline .litertlm models (e.g. Gemma 4 E4B it)
-    implementation("com.google.ai.edge.litertlm:litertlm-android:0.10.0")
+    implementation("com.google.ai.edge.litertlm:litertlm-android:0.9.0-alpha06")
 
     // Camera Core to potentially fix missing JNI lib issue
     implementation("androidx.camera:camera-core:1.4.0")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,7 +111,7 @@ dependencies {
     // MediaPipe GenAI for offline inference (LLM)
     implementation("com.google.mediapipe:tasks-genai:0.10.32")
     // LiteRT-LM for newer offline .litertlm models (e.g. Gemma 4 E4B it)
-    implementation("com.google.ai.edge.litertlm:litertlm-android:0.0.0-alpha06")
+    implementation("com.google.ai.edge.litertlm:litertlm-android:0.10.0")
 
     // Camera Core to potentially fix missing JNI lib issue
     implementation("androidx.camera:camera-core:1.4.0")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,7 +111,7 @@ dependencies {
     // MediaPipe GenAI for offline inference (LLM)
     implementation("com.google.mediapipe:tasks-genai:0.10.32")
     // LiteRT-LM for newer offline .litertlm models (e.g. Gemma 4 E4B it)
-    implementation("com.google.ai.edge.litertlm:litertlm-android:0.9.0-alpha06")
+    implementation("com.google.ai.edge.litertlm:litertlm-android:0.10.0")
 
     // Camera Core to potentially fix missing JNI lib issue
     implementation("androidx.camera:camera-core:1.4.0")

--- a/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
@@ -60,6 +60,7 @@ enum class ModelOption(
         "gemma-4-e4b-it",
         ApiProvider.GOOGLE,
         "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm/resolve/main/gemma-4-E4B-it.litertlm?download=true",
+        supportsScreenshot = false,
         isOfflineModel = true,
         offlineModelFilename = "gemma-4-E4B-it.litertlm"
     ),

--- a/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
@@ -60,7 +60,6 @@ enum class ModelOption(
         "gemma-4-e4b-it",
         ApiProvider.GOOGLE,
         "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm/resolve/main/gemma-4-E4B-it.litertlm?download=true",
-        supportsScreenshot = false,
         isOfflineModel = true,
         offlineModelFilename = "gemma-4-E4B-it.litertlm"
     ),

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -86,7 +86,6 @@ class PhotoReasoningViewModel(
 
     private var llmInference: LlmInference? = null
     private var liteRtEngine: Engine? = null
-    private var liteRtNativeLoaded = false
     private val TAG = "PhotoReasoningViewModel"
     
     // WebRTC & Signaling
@@ -344,11 +343,10 @@ class PhotoReasoningViewModel(
                             "abis=${Build.SUPPORTED_ABIS?.joinToString() ?: "unknown"}, " +
                             "modelPath=${modelFile.absolutePath}, modelSizeBytes=${modelFile.length()}"
                     )
-                    ensureLiteRtNativeLoaded()
                     if (liteRtEngine == null) {
-                        val liteRtBackend = if (backend == InferenceBackend.GPU) Backend.GPU else Backend.CPU
-                        val visionBackend = Backend.CPU
-                        val audioBackend = Backend.CPU
+                        val liteRtBackend = if (backend == InferenceBackend.GPU) Backend.GPU() else Backend.CPU()
+                        val visionBackend = if (currentModel.supportsScreenshot) Backend.GPU() else null
+                        val audioBackend = null
                         val engineConfig = EngineConfig(
                             modelPath = modelFile.absolutePath,
                             backend = liteRtBackend,
@@ -411,14 +409,6 @@ class PhotoReasoningViewModel(
                 "Offline model could not be initialized: $msg"
             }
         }
-    }
-
-    private fun ensureLiteRtNativeLoaded() {
-        if (liteRtNativeLoaded) return
-
-        System.loadLibrary("litertlm_jni")
-
-        liteRtNativeLoaded = true
     }
 
     private fun isLiteRtAbiSupported(): Boolean {

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -340,14 +340,20 @@ class PhotoReasoningViewModel(
                     }
                     ensureLiteRtNativeLoaded()
                     if (liteRtEngine == null) {
-                        val liteRtBackend = if (backend == InferenceBackend.GPU) Backend.GPU else Backend.CPU
+                        val liteRtBackend = Backend.CPU
+                        if (backend == InferenceBackend.GPU) {
+                            Log.w(
+                                TAG,
+                                "Gemma 4 offline currently forces CPU backend to avoid native crashes on GPU initialization."
+                            )
+                        }
                         val engineConfig = EngineConfig(
                             modelPath = modelFile.absolutePath,
                             backend = liteRtBackend,
                             cacheDir = context.cacheDir.absolutePath
                         )
                         liteRtEngine = Engine(engineConfig).also { it.initialize() }
-                        Log.d(TAG, "Offline model initialized with LiteRT-LM Engine backend=$backend")
+                        Log.d(TAG, "Offline model initialized with LiteRT-LM Engine backend=$liteRtBackend")
                     }
                 } else {
                     if (llmInference == null) {
@@ -456,7 +462,12 @@ class PhotoReasoningViewModel(
     }
 
     private fun isOfflineGpuModelLoaded(): Boolean {
-        return com.google.ai.sample.GenerativeAiViewModelFactory.getCurrentModel().isOfflineModel &&
+        val currentModel = com.google.ai.sample.GenerativeAiViewModelFactory.getCurrentModel()
+        if (currentModel == ModelOption.GEMMA_4_E4B_IT) {
+            // Gemma 4 offline currently runs with CPU backend for stability.
+            return false
+        }
+        return currentModel.isOfflineModel &&
             com.google.ai.sample.GenerativeAiViewModelFactory.getBackend() == InferenceBackend.GPU &&
             (llmInference != null || liteRtEngine != null)
     }

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -344,8 +344,8 @@ class PhotoReasoningViewModel(
                             "modelPath=${modelFile.absolutePath}, modelSizeBytes=${modelFile.length()}"
                     )
                     if (liteRtEngine == null) {
-                        val liteRtBackend = if (backend == InferenceBackend.GPU) Backend.GPU() else Backend.CPU()
-                        val visionBackend = if (currentModel.supportsScreenshot) Backend.CPU() else null
+                        val preferredBackend = if (backend == InferenceBackend.GPU) Backend.GPU() else Backend.CPU()
+                        val preferredVisionBackend = if (currentModel.supportsScreenshot) Backend.GPU() else null
                         val audioBackend = null
                         val cacheDir =
                             if (modelFile.absolutePath.startsWith("/data/local/tmp")) {
@@ -353,22 +353,14 @@ class PhotoReasoningViewModel(
                             } else {
                                 null
                             }
-                        val engineConfig = EngineConfig(
+                        liteRtEngine = createLiteRtEngineWithFallbacks(
                             modelPath = modelFile.absolutePath,
-                            backend = liteRtBackend,
-                            visionBackend = visionBackend,
+                            preferredBackend = preferredBackend,
+                            preferredVisionBackend = preferredVisionBackend,
                             audioBackend = audioBackend,
-                            maxNumTokens = null,
                             cacheDir = cacheDir
                         )
-                        Log.i(
-                            TAG,
-                            "Creating LiteRT engine with backend=$liteRtBackend, " +
-                                "visionBackend=$visionBackend, audioBackend=$audioBackend, " +
-                                "cacheDir=$cacheDir"
-                        )
-                        liteRtEngine = Engine(engineConfig).also { it.initialize() }
-                        Log.d(TAG, "Offline model initialized with LiteRT-LM Engine backend=$liteRtBackend")
+                        Log.d(TAG, "Offline model initialized with LiteRT-LM Engine")
                     }
                 } else {
                     if (llmInference == null) {
@@ -420,6 +412,63 @@ class PhotoReasoningViewModel(
     private fun isLiteRtAbiSupported(): Boolean {
         val supportedAbis = Build.SUPPORTED_ABIS?.toSet().orEmpty()
         return supportedAbis.contains("arm64-v8a") || supportedAbis.contains("x86_64")
+    }
+
+    private fun createLiteRtEngineWithFallbacks(
+        modelPath: String,
+        preferredBackend: Backend,
+        preferredVisionBackend: Backend?,
+        audioBackend: Backend?,
+        cacheDir: String?
+    ): Engine {
+        val cpuBackend = Backend.CPU()
+        val gpuBackend = Backend.GPU()
+        val attempts = linkedSetOf(
+            preferredBackend to preferredVisionBackend,
+            cpuBackend to preferredVisionBackend,
+            cpuBackend to cpuBackend,
+            gpuBackend to cpuBackend
+        )
+        var lastError: Exception? = null
+        val failureDetails = StringBuilder()
+
+        attempts.forEachIndexed { index, (backendAttempt, visionAttempt) ->
+            try {
+                Log.i(
+                    TAG,
+                    "LiteRT init attempt ${index + 1}/${attempts.size}: " +
+                        "backend=$backendAttempt visionBackend=$visionAttempt audioBackend=$audioBackend cacheDir=$cacheDir"
+                )
+                val config = EngineConfig(
+                    modelPath = modelPath,
+                    backend = backendAttempt,
+                    visionBackend = visionAttempt,
+                    audioBackend = audioBackend,
+                    maxNumTokens = null,
+                    cacheDir = cacheDir
+                )
+                return Engine(config).also { it.initialize() }
+            } catch (e: Exception) {
+                lastError = e
+                val msg = e.message ?: e.toString()
+                failureDetails
+                    .append("Attempt ")
+                    .append(index + 1)
+                    .append(" failed (backend=")
+                    .append(backendAttempt)
+                    .append(", visionBackend=")
+                    .append(visionAttempt)
+                    .append("): ")
+                    .append(msg)
+                    .append('\n')
+                Log.w(TAG, "LiteRT init attempt ${index + 1} failed", e)
+            }
+        }
+
+        throw IllegalStateException(
+            "All LiteRT initialization attempts failed.\n$failureDetails",
+            lastError
+        )
     }
     
     fun reinitializeOfflineModel(context: Context) {

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -57,7 +57,6 @@ import com.google.ai.sample.ApiProvider
 import com.google.ai.edge.litertlm.Backend
 import com.google.ai.edge.litertlm.Engine
 import com.google.ai.edge.litertlm.EngineConfig
-import com.google.ai.edge.litertlm.NativeLibraryLoader
 import com.google.mediapipe.tasks.genai.llminference.LlmInference
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -394,11 +393,7 @@ class PhotoReasoningViewModel(
     private fun ensureLiteRtNativeLoaded() {
         if (liteRtNativeLoaded) return
 
-        runCatching {
-            NativeLibraryLoader.INSTANCE.load()
-        }.recoverCatching {
-            System.loadLibrary("litertlm_jni")
-        }.getOrThrow()
+        System.loadLibrary("litertlm_jni")
 
         liteRtNativeLoaded = true
     }

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -338,19 +338,23 @@ class PhotoReasoningViewModel(
                     if (!isLiteRtAbiSupported()) {
                         return "Gemma 4 offline is only supported on arm64-v8a or x86_64 devices."
                     }
+                    Log.i(
+                        TAG,
+                        "Initializing Gemma 4 LiteRT engine. preferredBackend=$backend, " +
+                            "abis=${Build.SUPPORTED_ABIS?.joinToString() ?: "unknown"}, " +
+                            "modelPath=${modelFile.absolutePath}, modelSizeBytes=${modelFile.length()}"
+                    )
                     ensureLiteRtNativeLoaded()
                     if (liteRtEngine == null) {
-                        val liteRtBackend = Backend.CPU
-                        if (backend == InferenceBackend.GPU) {
-                            Log.w(
-                                TAG,
-                                "Gemma 4 offline currently forces CPU backend to avoid native crashes on GPU initialization."
-                            )
-                        }
+                        val liteRtBackend = if (backend == InferenceBackend.GPU) Backend.GPU else Backend.CPU
                         val engineConfig = EngineConfig(
                             modelPath = modelFile.absolutePath,
                             backend = liteRtBackend,
                             cacheDir = context.cacheDir.absolutePath
+                        )
+                        Log.i(
+                            TAG,
+                            "Creating LiteRT engine with backend=$liteRtBackend cacheDir=${context.cacheDir.absolutePath}"
                         )
                         liteRtEngine = Engine(engineConfig).also { it.initialize() }
                         Log.d(TAG, "Offline model initialized with LiteRT-LM Engine backend=$liteRtBackend")
@@ -381,6 +385,12 @@ class PhotoReasoningViewModel(
             return null // Already initialized or no model file
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize offline model", e)
+            Log.e(
+                TAG,
+                "Offline init context: model=${com.google.ai.sample.GenerativeAiViewModelFactory.getCurrentModel()}, " +
+                    "preferredBackend=${GenerativeAiViewModelFactory.getBackend()}, " +
+                    "abis=${Build.SUPPORTED_ABIS?.joinToString() ?: "unknown"}"
+            )
             val msg = e.message ?: e.toString()
             if (msg.contains("nativeCheckLoaded", ignoreCase = true) ||
                 msg.contains("No implementation found", ignoreCase = true) ||
@@ -462,12 +472,7 @@ class PhotoReasoningViewModel(
     }
 
     private fun isOfflineGpuModelLoaded(): Boolean {
-        val currentModel = com.google.ai.sample.GenerativeAiViewModelFactory.getCurrentModel()
-        if (currentModel == ModelOption.GEMMA_4_E4B_IT) {
-            // Gemma 4 offline currently runs with CPU backend for stability.
-            return false
-        }
-        return currentModel.isOfflineModel &&
+        return com.google.ai.sample.GenerativeAiViewModelFactory.getCurrentModel().isOfflineModel &&
             com.google.ai.sample.GenerativeAiViewModelFactory.getBackend() == InferenceBackend.GPU &&
             (llmInference != null || liteRtEngine != null)
     }

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -347,14 +347,21 @@ class PhotoReasoningViewModel(
                     ensureLiteRtNativeLoaded()
                     if (liteRtEngine == null) {
                         val liteRtBackend = if (backend == InferenceBackend.GPU) Backend.GPU else Backend.CPU
+                        val visionBackend = Backend.CPU
+                        val audioBackend = Backend.CPU
                         val engineConfig = EngineConfig(
                             modelPath = modelFile.absolutePath,
                             backend = liteRtBackend,
+                            visionBackend = visionBackend,
+                            audioBackend = audioBackend,
+                            maxNumTokens = null,
                             cacheDir = context.cacheDir.absolutePath
                         )
                         Log.i(
                             TAG,
-                            "Creating LiteRT engine with backend=$liteRtBackend cacheDir=${context.cacheDir.absolutePath}"
+                            "Creating LiteRT engine with backend=$liteRtBackend, " +
+                                "visionBackend=$visionBackend, audioBackend=$audioBackend, " +
+                                "cacheDir=${context.cacheDir.absolutePath}"
                         )
                         liteRtEngine = Engine(engineConfig).also { it.initialize() }
                         Log.d(TAG, "Offline model initialized with LiteRT-LM Engine backend=$liteRtBackend")

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -345,21 +345,27 @@ class PhotoReasoningViewModel(
                     )
                     if (liteRtEngine == null) {
                         val liteRtBackend = if (backend == InferenceBackend.GPU) Backend.GPU() else Backend.CPU()
-                        val visionBackend = if (currentModel.supportsScreenshot) Backend.GPU() else null
+                        val visionBackend = if (currentModel.supportsScreenshot) Backend.CPU() else null
                         val audioBackend = null
+                        val cacheDir =
+                            if (modelFile.absolutePath.startsWith("/data/local/tmp")) {
+                                context.getExternalFilesDir(null)?.absolutePath
+                            } else {
+                                null
+                            }
                         val engineConfig = EngineConfig(
                             modelPath = modelFile.absolutePath,
                             backend = liteRtBackend,
                             visionBackend = visionBackend,
                             audioBackend = audioBackend,
                             maxNumTokens = null,
-                            cacheDir = context.cacheDir.absolutePath
+                            cacheDir = cacheDir
                         )
                         Log.i(
                             TAG,
                             "Creating LiteRT engine with backend=$liteRtBackend, " +
                                 "visionBackend=$visionBackend, audioBackend=$audioBackend, " +
-                                "cacheDir=${context.cacheDir.absolutePath}"
+                                "cacheDir=$cacheDir"
                         )
                         liteRtEngine = Engine(engineConfig).also { it.initialize() }
                         Log.d(TAG, "Offline model initialized with LiteRT-LM Engine backend=$liteRtBackend")

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -57,6 +57,7 @@ import com.google.ai.sample.ApiProvider
 import com.google.ai.edge.litertlm.Backend
 import com.google.ai.edge.litertlm.Engine
 import com.google.ai.edge.litertlm.EngineConfig
+import com.google.ai.edge.litertlm.NativeLibraryLoader
 import com.google.mediapipe.tasks.genai.llminference.LlmInference
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -86,6 +87,7 @@ class PhotoReasoningViewModel(
 
     private var llmInference: LlmInference? = null
     private var liteRtEngine: Engine? = null
+    private var liteRtNativeLoaded = false
     private val TAG = "PhotoReasoningViewModel"
     
     // WebRTC & Signaling
@@ -337,6 +339,7 @@ class PhotoReasoningViewModel(
                     if (!isLiteRtAbiSupported()) {
                         return "Gemma 4 offline is only supported on arm64-v8a or x86_64 devices."
                     }
+                    ensureLiteRtNativeLoaded()
                     if (liteRtEngine == null) {
                         val liteRtBackend = if (backend == InferenceBackend.GPU) Backend.GPU else Backend.CPU
                         val engineConfig = EngineConfig(
@@ -386,6 +389,18 @@ class PhotoReasoningViewModel(
                 "Offline model could not be initialized: $msg"
             }
         }
+    }
+
+    private fun ensureLiteRtNativeLoaded() {
+        if (liteRtNativeLoaded) return
+
+        runCatching {
+            NativeLibraryLoader.INSTANCE.load()
+        }.recoverCatching {
+            System.loadLibrary("litertlm_jni")
+        }.getOrThrow()
+
+        liteRtNativeLoaded = true
     }
 
     private fun isLiteRtAbiSupported(): Boolean {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ buildscript {
 }
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.3" apply false
+    id("com.android.application") version "8.8.2" apply false
     id("org.jetbrains.kotlin.android") version "1.9.20" apply false
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin") version "2.0.1" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Motivation
- Beim Start des Gemma‑4 Offline-Modells trat ein JNI-Fehler (`nativeCheckLoaded` / "No implementation found ...") auf; diese Änderung stellt sicher, dass die LiteRT-JNI-Bibliothek geladen ist, bevor die Engine initialisiert wird.

### Description
- Importiert `NativeLibraryLoader`, ergänzt das Flag `liteRtNativeLoaded` und fügt `ensureLiteRtNativeLoaded()` hinzu, das `NativeLibraryLoader.INSTANCE.load()` aufruft und bei Fehlschlag als Fallback `System.loadLibrary("litertlm_jni")` verwendet, und ruft diese Funktion vor `Engine(engineConfig).initialize()` auf.

### Testing
- Automatisierte Tasks `./gradlew :app:lintDebug` und `./gradlew :app:assembleDebug` wurden ausgeführt und schlugen fehl wegen fehlender Android SDK-Konfiguration (`SDK location not found`), daher konnten die Builds in dieser Umgebung nicht erfolgreich abgeschlossen werden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8ab44af988321a2c4cd5bc951948d)