### PR TITLE
Puter-Modell auf GLM-5V Turbo umstellen und Screenshots aktivieren

### DIFF
--- a/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
@@ -31,7 +31,7 @@ enum class ModelOption(
     val isOfflineModel: Boolean = false,
     val offlineModelFilename: String? = null
 ) {
-    PUTER_GLM5("GLM-5 (Puter)", "z-ai/glm-5", ApiProvider.PUTER, supportsScreenshot = false),
+    PUTER_GLM5("GLM-5V Turbo (Puter)", "openrouter:z-ai/glm-5v-turbo", ApiProvider.PUTER, supportsScreenshot = true),
     MISTRAL_LARGE_3("Mistral Large 3", "mistral-large-latest", ApiProvider.MISTRAL),
     MISTRAL_MEDIUM_3_1("Mistral Medium 3.1", "mistral-medium-latest", ApiProvider.MISTRAL),
     GPT_5_1_CODEX_MAX("GPT-5.1 Codex Max (Vercel)", "openai/gpt-5.1-codex-max", ApiProvider.VERCEL),


### PR DESCRIPTION
### Motivation
- Das Puter-Modell `GLM-5` soll durch `GLM-5V Turbo (openrouter:z-ai/glm-5v-turbo)` ersetzt werden und die Screenshot-Unterstützung für dieses Modell aktiviert werden.

### Description
- In `app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt` wurde `PUTER_GLM5` auf den Anzeigenamen `GLM-5V Turbo (Puter)` aktualisiert, der `modelName` auf `openrouter:z-ai/glm-5v-turbo` geändert und `supportsScreenshot` auf `true` gesetzt.

### Testing
- Automation: `./gradlew :app:lintDebug` ausgeführt; Lint/Build konnte nicht abgeschlossen werden, weil in dieser Umgebung die Datei `local.properties` fehlt, daher war kein erfolgreicher Lint-Durchlauf möglich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92e72268083219ce93f6d74f7e019)