### PR TITLE
Stop injecting generic prompt text for auto-screenshot requests

### DIFF
--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -1316,27 +1316,37 @@ class PhotoReasoningViewModel(
             if (systemContent.isNotEmpty())
                 apiMessages.add(MistralMessage(role = "system", content = systemContent))
 
-            _chatState.getAllMessages()
+            val allMessages = _chatState.getAllMessages()
+            val historyMessages = allMessages
                 .filter { !it.isPending && it.participant != PhotoParticipant.ERROR }
-                .forEach { message ->
-                    val role = if (message.participant == PhotoParticipant.USER) "user" else "assistant"
-                    val contentParts = mutableListOf<MistralContent>()
-                    if (message.text.isNotBlank()) contentParts.add(MistralTextContent(text = message.text))
-                    if (contentParts.isNotEmpty()) apiMessages.add(MistralMessage(role = role, content = contentParts))
-                }
+                .dropLast(1)
 
-            if (selectedImages.isNotEmpty() && apiMessages.isNotEmpty() && currentModel.supportsScreenshot) {
-                val lastUserMsg = apiMessages.last()
-                if (lastUserMsg.role == "user") {
-                    val updatedContent = lastUserMsg.content.toMutableList()
-                    for (bitmap in selectedImages)
-                        updatedContent.add(
-                            MistralImageContent(
-                                imageUrl = "data:image/jpeg;base64,${PhotoReasoningSerialization.bitmapToBase64(bitmap)}"
-                            )
-                        )
-                    apiMessages[apiMessages.lastIndex] = lastUserMsg.copy(content = updatedContent)
+            historyMessages.forEach { message ->
+                val role = if (message.participant == PhotoParticipant.USER) "user" else "assistant"
+                val contentParts = mutableListOf<MistralContent>()
+                if (message.text.isNotBlank()) {
+                    contentParts.add(MistralTextContent(text = message.text))
                 }
+                if (contentParts.isNotEmpty()) {
+                    apiMessages.add(MistralMessage(role = role, content = contentParts))
+                }
+            }
+
+            val currentContentParts = mutableListOf<MistralContent>()
+            if (combinedPromptText.isNotBlank()) {
+                currentContentParts.add(MistralTextContent(text = combinedPromptText))
+            }
+            if (currentModel.supportsScreenshot) {
+                selectedImages.forEach { bitmap ->
+                    currentContentParts.add(
+                        MistralImageContent(
+                            imageUrl = "data:image/jpeg;base64,${PhotoReasoningSerialization.bitmapToBase64(bitmap)}"
+                        )
+                    )
+                }
+            }
+            if (currentContentParts.isNotEmpty()) {
+                apiMessages.add(MistralMessage(role = "user", content = currentContentParts))
             }
 
             val jsonSerializer = Json {
@@ -2166,32 +2176,6 @@ class PhotoReasoningViewModel(
     }
 
     private fun createGenericScreenshotPrompt(): String {
-        val latestTask = latestUserTaskInput.trim()
-        if (latestTask.isNotBlank()) {
-            return latestTask
-        }
-
-        val lastUserMessage = _chatState.getAllMessages()
-            .asReversed()
-            .firstOrNull { it.participant == PhotoParticipant.USER && it.text.isNotBlank() }
-            ?.text
-            ?.trim()
-
-        if (!lastUserMessage.isNullOrBlank()) {
-            val screenInfoMarker = "\n\nScreen elements:\n"
-            return lastUserMessage.substringBefore(screenInfoMarker).trim()
-        }
-
-        val persistedInput = _userInput.value.trim()
-        if (persistedInput.isNotBlank()) {
-            return persistedInput
-        }
-
-        val lastKnownInput = currentUserInput.trim()
-        if (lastKnownInput.isNotBlank()) {
-            return lastKnownInput
-        }
-
         return ""
     }
 


### PR DESCRIPTION
## Summary
- removed the hardcoded auto-screenshot instruction text by making `createGenericScreenshotPrompt()` return an empty string
- reworked `reasonWithMistral()` request assembly so the current turn is explicitly appended as a fresh user message
  - history now includes system message + database context + prior non-pending chat messages
  - current turn now adds text only when present and always attaches current screenshot images

## Why
Auto-screenshot requests should not re-inject synthetic text into each turn. The UI should keep normal chat behavior while providers still receive full context (system message + database + chat history + current screenshot input).

## Scope
- `app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt`

## Validation
- static inspection of `addScreenshotToConversation` -> `reason` -> `reasonWithMistral` flow
- ensured no new imports required

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e522b593e08324b26add682249438b)