### PR TITLE
Chat: '+'-Taste unterstützt jetzt Bilder und Videos

### DIFF
--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningRoute.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningRoute.kt
@@ -1,7 +1,9 @@
 package com.google.ai.sample.feature.multimodal
 
 import android.content.Intent
+import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
+import android.media.MediaMetadataRetriever
 import android.provider.Settings
 import android.net.Uri
 import android.widget.Toast
@@ -30,6 +32,7 @@ import com.google.ai.sample.GenerativeViewModelFactory
 import com.google.ai.sample.MainActivity
 import com.google.ai.sample.ModelOption
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 internal fun PhotoReasoningRoute(
@@ -99,12 +102,13 @@ internal fun PhotoReasoningRoute(
         },
         onReasonClicked = { inputText, selectedItems ->
             coroutineScope.launch {
-                val bitmaps = selectedItems.mapNotNull {
-                    val imageRequest = imageRequestBuilder.data(it).precision(Precision.EXACT).build()
-                    try {
-                        val result = imageLoader.execute(imageRequest)
-                        if (result is SuccessResult) (result.drawable as BitmapDrawable).bitmap else null
-                    } catch (e: Exception) { null }
+                val bitmaps = selectedItems.mapNotNull { uri ->
+                    uriToBitmap(
+                        uri = uri,
+                        context = context,
+                        imageRequestBuilder = imageRequestBuilder,
+                        imageLoader = imageLoader
+                    )
                 }
                 viewModel.reason(
                     userInput = inputText,
@@ -139,4 +143,36 @@ internal fun PhotoReasoningRoute(
         isOfflineGpuModelLoaded = isOfflineGpuModelLoaded,
         isInitializingOfflineModel = isInitializingOfflineModel
     )
+}
+
+private suspend fun uriToBitmap(
+    uri: Uri,
+    context: android.content.Context,
+    imageRequestBuilder: ImageRequest.Builder,
+    imageLoader: ImageLoader
+): Bitmap? = withContext(kotlinx.coroutines.Dispatchers.IO) {
+    val mimeType = context.contentResolver.getType(uri).orEmpty()
+    if (mimeType.startsWith("video/")) {
+        return@withContext extractVideoFrame(context, uri)
+    }
+
+    val imageRequest = imageRequestBuilder.data(uri).precision(Precision.EXACT).build()
+    return@withContext try {
+        val result = imageLoader.execute(imageRequest)
+        if (result is SuccessResult) (result.drawable as? BitmapDrawable)?.bitmap else null
+    } catch (e: Exception) {
+        null
+    }
+}
+
+private fun extractVideoFrame(context: android.content.Context, uri: Uri): Bitmap? {
+    val retriever = MediaMetadataRetriever()
+    return try {
+        retriever.setDataSource(context, uri)
+        retriever.getFrameAtTime(0)
+    } catch (e: Exception) {
+        null
+    } finally {
+        retriever.release()
+    }
 }

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningRoute.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningRoute.kt
@@ -170,9 +170,17 @@ private fun extractVideoFrame(context: android.content.Context, uri: Uri): Bitma
     return try {
         retriever.setDataSource(context, uri)
         retriever.getFrameAtTime(0)
-    } catch (e: Exception) {
+    } catch (e: IllegalArgumentException) {
+        android.util.Log.e("PhotoReasoningRoute", "Invalid video URI: $uri", e)
+        null
+    } catch (e: RuntimeException) {
+        android.util.Log.e("PhotoReasoningRoute", "Failed to extract video frame: $uri", e)
         null
     } finally {
-        retriever.release()
+        try {
+            retriever.release()
+        } catch (e: Exception) {
+            android.util.Log.e("PhotoReasoningRoute", "Failed to release MediaMetadataRetriever", e)
+        }
     }
 }

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningRoute.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningRoute.kt
@@ -173,14 +173,14 @@ private fun extractVideoFrame(context: android.content.Context, uri: Uri): Bitma
     } catch (e: IllegalArgumentException) {
         android.util.Log.e("PhotoReasoningRoute", "Invalid video URI: $uri", e)
         null
-    } catch (e: RuntimeException) {
-        android.util.Log.e("PhotoReasoningRoute", "Failed to extract video frame: $uri", e)
+private fun extractVideoFrame(context: android.content.Context, uri: Uri): Bitmap? {
+    val retriever = MediaMetadataRetriever()
+    return try {
+        retriever.setDataSource(context, uri)
+        retriever.getFrameAtTime(0, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
+    } catch (e: Exception) {
         null
     } finally {
-        try {
-            retriever.release()
-        } catch (e: Exception) {
-            android.util.Log.e("PhotoReasoningRoute", "Failed to release MediaMetadataRetriever", e)
-        }
+        retriever.release()
     }
 }

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningScreen.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningScreen.kt
@@ -381,7 +381,7 @@ fun PhotoReasoningScreen(
                 Column(modifier = Modifier.fillMaxWidth()) {
                     Row(modifier = Modifier.padding(top = 16.dp)) {
                         Column(modifier = Modifier.padding(all = 4.dp).align(Alignment.CenterVertically)) {
-                            IconButton(onClick = { pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)) }, modifier = Modifier.padding(bottom = 4.dp)) {
+                            IconButton(onClick = { pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageAndVideo)) }, modifier = Modifier.padding(bottom = 4.dp)) {
                                 Icon(Icons.Rounded.Add, stringResource(R.string.add_image))
                             }
                             IconButton(onClick = onClearChatHistory, modifier = Modifier.padding(top = 4.dp).drawBehind {


### PR DESCRIPTION
### Motivation
- Die Medienauswahl im Chat sollte nicht mehr nur Bilder, sondern auch Videos akzeptieren, damit Nutzer kurze Videoinhalte als Input für die Photo-Reasoning-Flow nutzen können.
- Videos müssen in den bestehenden Bitmap-basierten Processing-Flow integriert werden, ohne das bisherige Bildverhalten zu brechen.

### Description
- Die `+`-Taste im Chat wurde geändert, damit der Media Picker `ImageAndVideo` statt nur `ImageOnly` öffnet (`PhotoReasoningScreen.kt`).
- Die Auswahlverarbeitung wurde in `PhotoReasoningRoute.kt` auf eine neue `uriToBitmap`-Funktion ausgelagert, die anhand des MIME-Typs zwischen Bild- und Video-URIs unterscheidet.
- Für Video-URIs wird jetzt mit `MediaMetadataRetriever#getFrameAtTime` ein Frame extrahiert und als `Bitmap` zurückgegeben, während Bilder wie bisher über Coil (`ImageLoader` / `ImageRequest`) zu `Bitmap` konvertiert werden.
- Imports und Coroutine-Usage ergänzt (`Bitmap`, `MediaMetadataRetriever`, `withContext`) und bestehende Bild-Flow-Logik beibehalten; Fehlerfälle liefern `null` und werden still behandelt.

### Testing
- `./gradlew :app:lintDebug` wurde ausgeführt, schlug in der Container-Umgebung fehl aufgrund fehlender Android-SDK-Konfiguration (`SDK location not found`).
- Quellcodeänderungen wurden lokal dem Git-Index hinzugefügt und mit `git commit` erfasst, Commit lief erfolgreich.
- Keine weiteren automatisierten Tests wurden in dieser Umgebung ausgeführt, da ein vollständiger Build/Lint nicht möglich war ohne konfiguriertes Android SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b1e771008321af951ffe82b7c985)