### PR TITLE
Add PUTER Qwen3.5-Flash model option and display hint in menu

### DIFF
--- a/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
@@ -37,6 +37,7 @@ enum class ModelOption(
 ) {
     PUTER_GPT_5_4_NANO("GPT-5.4 Nano (Puter)", "openai/gpt-5.4-nano", ApiProvider.PUTER, supportsScreenshot = true),
     PUTER_GLM5("GLM-5V Turbo (Puter)", "openrouter:z-ai/glm-5v-turbo", ApiProvider.PUTER, supportsScreenshot = true),
+    PUTER_QWEN3_5_FLASH("Qwen3.5-Flash (Puter)", "qwen/qwen3.5-flash-02-23", ApiProvider.PUTER, supportsScreenshot = true),
     MISTRAL_LARGE_3("Mistral Large 3", "mistral-large-latest", ApiProvider.MISTRAL),
     MISTRAL_MEDIUM_3_1("Mistral Medium 3.1", "mistral-medium-latest", ApiProvider.MISTRAL),
     GPT_5_1_CODEX_MAX("GPT-5.1 Codex Max (Vercel)", "openai/gpt-5.1-codex-max", ApiProvider.VERCEL),

--- a/app/src/main/kotlin/com/google/ai/sample/MenuScreen.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/MenuScreen.kt
@@ -293,6 +293,7 @@ fun MenuScreen(
                             ModelOption.MISTRAL_LARGE_3 -> "Mistral AI rejects requests containing non-black images with a 429 Error: Rate limit exceeded response"
                             ModelOption.GEMINI_3_FLASH -> "Google often rejects requests to this model with a 503 Model is exhausted error"
                             ModelOption.PUTER_GLM5 -> "This model is expensive and uses up the free quota quickly. Consider GPT-5.4 Nano."
+                            ModelOption.PUTER_QWEN3_5_FLASH -> "$0.07/M input | $0.26/M output"
                             ModelOption.GPT_5_1_CODEX_MAX,
                             ModelOption.GPT_5_1_CODEX_MINI,
                             ModelOption.GPT_5_NANO -> "Vercel requires a credit card"


### PR DESCRIPTION
### Motivation
- Expose the new PUTER Qwen3.5-Flash model in the app's model list and surface a concise cost hint in the model selection UI so users see pricing info for that provider.

### Description
- Add `PUTER_QWEN3_5_FLASH` to `ModelOption` with provider `ApiProvider.PUTER` and model name `qwen/qwen3.5-flash-02-23` in `GenerativeAiViewModelFactory.kt`.
- Show a short pricing hint for `ModelOption.PUTER_QWEN3_5_FLASH` in `MenuScreen.kt` so it appears under the model selection.

### Testing
- Ran a local build with `./gradlew assembleDebug` and executed unit tests with `./gradlew test`, and the build and tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ca0206f88324aa2b36b6befd7388)