### PR TITLE
Enable Kotlin Compose plugin, remove explicit compiler extension, and add Android GUI workflow script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ buildscript {
 plugins {
     id("com.android.application") version "8.8.2" apply false
     id("org.jetbrains.kotlin.android") version "2.1.20" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.1.20" apply false
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin") version "2.0.1" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
 }

--- a/humanoperator/build.gradle.kts
+++ b/humanoperator/build.gradle.kts
@@ -3,6 +3,7 @@ import java.io.ByteArrayOutputStream
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.gms.google-services")
 }
 
@@ -72,9 +73,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.4"
     }
     packaging {
         jniLibs {

--- a/scripts/full_android_gui_workflow.sh
+++ b/scripts/full_android_gui_workflow.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Virtueller Desktop (GUI)
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y xvfb x11vnc fluxbox xterm scrot curl jq ca-certificates lxc uidmap dbus
+
+mkdir -p /tmp/virt-desktop
+Xvfb :2 -screen 0 1920x1080x24 >/tmp/virt-desktop/xvfb2.log 2>&1 &
+for _ in $(seq 1 20); do
+  DISPLAY=:2 xdpyinfo >/dev/null 2>&1 && break
+  sleep 1
+done
+fluxbox -display :2 >/tmp/virt-desktop/fluxbox2.log 2>&1 &
+x11vnc -display :2 -nopw -forever -shared -rfbport 5902 >/tmp/virt-desktop/x11vnc2.log 2>&1 &
+DISPLAY=:2 xterm -display :2 -e 'echo Virtueller Desktop aktiv; bash' >/tmp/virt-desktop/xterm2.log 2>&1 &
+
+# Alternative zum Android SDK Emulator: Waydroid (LXC-basiert)
+# Repository + Installation
+curl -fsSL https://repo.waydro.id | bash
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y waydroid
+
+# Waydroid initialisieren und starten
+waydroid init
+systemctl start waydroid-container || true
+waydroid session start
+
+# Screenshots (Desktop + Android-Container)
+DISPLAY=:2 scrot /tmp/virt-desktop/desktop2.png
+waydroid screenshot /tmp/virt-desktop/waydroid_screen.png
+
+# Aktuelle Termux-APK-URL bereitstellen
+curl -fsSL https://api.github.com/repos/termux/termux-app/releases/latest | jq -r '.assets[] | select(.name|test("github-debug_universal\\.apk$")) | .browser_download_url' | head -n1 > /tmp/virt-desktop/termux_latest_url.txt


### PR DESCRIPTION
### Motivation
- Enable the Kotlin Compose plugin at the project and module levels to support Compose compiler integration and future Compose features.
- Remove a hardcoded `kotlinCompilerExtensionVersion` entry to rely on the plugin-managed or coordinated compiler extension version.
- Provide a reproducible virtual desktop and Android-container workflow to run GUI/emulator tasks in CI or local automation.

### Description
- Added `id("org.jetbrains.kotlin.plugin.compose") version "2.1.20" apply false` to the root `build.gradle.kts` to make the Compose plugin available to subprojects.
- Applied `id("org.jetbrains.kotlin.plugin.compose")` in `humanoperator/build.gradle.kts` to enable Compose compiler support for that module.
- Removed the `composeOptions { kotlinCompilerExtensionVersion = "1.5.4" }` block from `humanoperator/build.gradle.kts` to avoid a hardcoded extension version.
- Added an executable script `scripts/full_android_gui_workflow.sh` that installs and starts a virtual X desktop, `x11vnc`/`fluxbox`, initializes and starts `waydroid`, captures screenshots, and fetches the latest Termux APK URL for GUI/emulator workflows.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f876db307c83218efcfabeb562dbc9)