### PR TITLE
Termux: RUN_COMMAND-Berechtigung hinzufügen und RunCommandService gezielt ansprechen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
     <!-- Notification permission for Android 13+ (API 33+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+    <uses-permission android:name="com.termux.permission.RUN_COMMAND" />
 
     <application
         android:name=".PhotoReasoningApplication"

--- a/app/src/main/kotlin/com/google/ai/sample/ScreenOperatorAccessibilityService.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/ScreenOperatorAccessibilityService.kt
@@ -502,10 +502,12 @@ class ScreenOperatorAccessibilityService : AccessibilityService() {
         }
         val intent = Intent("com.termux.RUN_COMMAND").apply {
             `package` = termuxPackage
+            setClassName(termuxPackage, "com.termux.app.RunCommandService")
             putExtra("com.termux.RUN_COMMAND_PATH", "/data/data/com.termux/files/usr/bin/bash")
             putExtra("com.termux.RUN_COMMAND_ARGUMENTS", arrayOf("-lc", command))
             putExtra("com.termux.RUN_COMMAND_WORKDIR", "/data/data/com.termux/files/home")
             putExtra("com.termux.RUN_COMMAND_BACKGROUND", true)
+            putExtra("com.termux.RUN_COMMAND_SESSION_ACTION", 0)
         }
         try {
             startService(intent)


### PR DESCRIPTION
### Motivation
- Sicherstellen, dass die App externe Termux-Befehle zuverlässig ausführen kann, indem die benötigte Berechtigung und ein expliziter Service-Ziel-Intent gesetzt werden.
- Verbesserung der Robustheit bei der praktischen Ausführung von `Termux("...")`-Befehlen im Accessibility-Service.

### Description
- Fügt `com.termux.permission.RUN_COMMAND` in `app/src/main/AndroidManifest.xml` hinzu.
- Setzt im `executeTermuxCommand`-Intent in `app/src/main/kotlin/com/google/ai/sample/ScreenOperatorAccessibilityService.kt` die Zielklasse auf `com.termux.app.RunCommandService`.
- Fügt das Extra `com.termux.RUN_COMMAND_SESSION_ACTION` mit dem Integer-Wert `0` hinzu, um eine neue Termux-Session zu erzwingen und die Ausführungszuverlässigkeit zu verbessern.

### Testing
- Ausgeführt: `./gradlew :app:testDebugUnitTest`.
- Ergebnis: Das Projekt kompiliert, aber `:app:testDebugUnitTest` schlägt fehl, da 6 Unit-Tests in `CommandParserTest` fehlschlagen (vorhandene/ungeänderte Tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b96ee664832bb153b5b2248be6f2)