### PR TITLE
CI-Compile-Check deaktivierbar machen und Stop bricht Wait/Delayed-Screenshots ab

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -6,6 +6,18 @@ on:
   workflow_dispatch:  # Ermöglicht manuelle Ausführung des Workflows
 
 jobs:
+  # Schalter für optionalen Compile-Check in CI.
+  # "false" => Compile-Schritte werden übersprungen, Code bleibt aber im Workflow erhalten.
+  # Auf "true" setzen, falls der dedizierte Compile-Check wieder aktiviert werden soll.
+  compile-check-config:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.flags.outputs.enabled }}
+    steps:
+    - name: Set compile-check flag
+      id: flags
+      run: echo "enabled=false" >> $GITHUB_OUTPUT
+
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
@@ -61,7 +73,8 @@ jobs:
         echo "Results: app=$APP_CHANGED, humanoperator=$HUMANOPERATOR_CHANGED, shared=$SHARED_CHANGED"
 
   compile-check:
-    needs: detect-changes
+    needs: [detect-changes, compile-check-config]
+    if: needs.compile-check-config.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -105,7 +118,8 @@ jobs:
       run: ./gradlew :humanoperator:compileDebugKotlin
 
   build:
-    needs: [detect-changes, compile-check]
+    needs: [detect-changes, compile-check, compile-check-config]
+    if: always() && !cancelled() && (needs.compile-check.result == 'success' || needs.compile-check.result == 'skipped')
     runs-on: ubuntu-latest
     env:
       BUILD_APP: ${{ needs.detect-changes.outputs.app_changed == 'true' || needs.detect-changes.outputs.shared_changed == 'true' }}

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -1715,6 +1715,9 @@ class PhotoReasoningViewModel(
 
     fun onStopClicked() {
         _showStopNotificationFlow.value = false
+        // Stop muss auch während Wait(...) sofort wirken:
+        // Wartende Accessibility-Kommandos/Delayed-Screenshot immer abbrechen.
+        ScreenOperatorAccessibilityService.clearCommandQueue()
 
         val generationRunning = isGenerationRunning()
 
@@ -1738,8 +1741,6 @@ class PhotoReasoningViewModel(
         stopExecutionFlag.set(true)
         currentReasoningJob?.cancel()
         commandProcessingJob?.cancel()
-        // NEU:
-        ScreenOperatorAccessibilityService.clearCommandQueue()
 
         val messages = _chatState.getAllMessages().toMutableList()
         val lastMessage = messages.lastOrNull()


### PR DESCRIPTION
### Motivation
- Der vorhandene Compile-Check in GitHub Actions soll nicht gelöscht, sondern standardmäßig deaktivierbar bleiben, damit die Logik erhalten bleibt und bei Bedarf wieder aktiviert werden kann.
- Die `Stop`-Aktion muss auch während eines laufenden `Wait(seconds)` bzw. bei verzögerten Screenshots sofort wirken und verhindern, dass nach Ablauf des Waits eine neue Anfrage ausgelöst wird.

### Description
- Fügt in `.github/workflows/manual.yml` einen kleinen Flag-Job `compile-check-config` hinzu, der ein `enabled`-Output (`enabled=false`) liefert und den bestehenden `compile-check`-Job bedingt macht, so dass der Compile-Check standardmäßig übersprungen wird, ohne Code zu löschen.
- Verknüpft den `build`-Job mit dem neuen Flag-Job und passt die `if`/`needs`-Bedingungen an, damit `build` auch weiterläuft, wenn `compile-check` übersprungen wurde.
- Ruft in `PhotoReasoningViewModel.onStopClicked()` frühzeitig `ScreenOperatorAccessibilityService.clearCommandQueue()` auf, so dass wartende Accessibility-Kommandos und verzögerte Screenshot-Runnables sofort abgebrochen werden und `Stop` während `Wait(...)` wirkt.

### Testing
- Lokaler Kotlin-Compile: `./gradlew :app:compileDebugKotlin` wurde ausgeführt und der Build war erfolgreich (`BUILD SUCCESSFUL`).
- Änderungen an der Workflow-Logik wurden geprüft, indem die aktualisierte `.github/workflows/manual.yml` syntaktisch angepasst und konditionale Abhängigkeiten gesetzt wurden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc828628b88324ad98a51941ec27a4)